### PR TITLE
Add block mode as alternative to image redaction

### DIFF
--- a/src/main/java/io/gravitee/policy/llm/image/LlmImagePolicy.java
+++ b/src/main/java/io/gravitee/policy/llm/image/LlmImagePolicy.java
@@ -171,27 +171,26 @@ public class LlmImagePolicy implements HttpPolicy {
       )
       .toList()
       .flatMapCompletable(results -> {
-        List<ValidationResult> failures = results
-          .stream()
-          .filter(r -> !r.valid())
-          .toList();
+        List<ValidationResult> failures = new java.util.ArrayList<>();
 
+        // Log all results and collect failures in single pass
         for (ValidationResult result : results) {
           log.info(
             "Validation result for image at {}: {}",
             String.join(".", result.image().jsonPath()),
             result.valid() ? "PASSED" : "FAILED"
           );
+          if (!result.valid()) {
+            failures.add(result);
+          }
         }
 
         if (failures.isEmpty()) {
           return Completable.complete();
         }
 
-        // Check violation mode from config
-        ViolationMode mode = effectiveConfig.getOnViolation() != null
-          ? effectiveConfig.getOnViolation()
-          : ViolationMode.BLOCK;
+        // Check violation mode from config (configuration guarantees non-null)
+        ViolationMode mode = effectiveConfig.getOnViolation();
 
         if (mode == ViolationMode.BLOCK) {
           log.info(

--- a/src/main/java/io/gravitee/policy/llm/image/LlmImagePolicy.java
+++ b/src/main/java/io/gravitee/policy/llm/image/LlmImagePolicy.java
@@ -16,6 +16,7 @@
 package io.gravitee.policy.llm.image;
 
 import io.gravitee.gateway.api.buffer.Buffer;
+import io.gravitee.gateway.reactive.api.ExecutionFailure;
 import io.gravitee.gateway.reactive.api.context.http.HttpPlainExecutionContext;
 import io.gravitee.gateway.reactive.api.policy.http.HttpPolicy;
 import io.reactivex.rxjava3.core.Completable;
@@ -33,25 +34,31 @@ public class LlmImagePolicy implements HttpPolicy {
   private static final String POLICY_ID = "policy-llm-image";
   private static final String REDACTED_MESSAGE =
     "[Image redacted: validation failed]";
+
+  // Block mode error response
+  private static final String BLOCK_ERROR_KEY = "IMAGE_VALIDATION_FAILED";
+  private static final String BLOCK_ERROR_MESSAGE =
+    "Request blocked: inappropriate image(s) detected";
+  private static final int BLOCK_STATUS_CODE = 400;
   private static final String ENV_VISION_ENDPOINT =
     "http://localhost:8082/local-llm/chat/completions";
 
   private static final String DEFAULT_MODEL_NAME = "qwen3-vl:qwen3-vl:2b";
   private static final String PROMPT_TEMPLATE =
     """
-    You are an image content moderator. Analyze this image and determine if it should be ACCEPTED or REJECTED.
+      You are an image content moderator. Analyze this image and determine if it should be ACCEPTED or REJECTED.
 
-    REJECT images that contain:
-    %s
+      REJECT images that contain:
+      %s
 
-    ACCEPT images that are:
-    %s
+      ACCEPT images that are:
+      %s
 
-    Respond ONLY with a JSON object in this exact format:
-    {"decision": "ACCEPT" or "REJECT", "confidence": 0.0-1.0, "reason": "brief explanation", "flags": ["list", "of", "concerns"]}
+      Respond ONLY with a JSON object in this exact format:
+      {"decision": "ACCEPT" or "REJECT", "confidence": 0.0-1.0, "reason": "brief explanation", "flags": ["list", "of", "concerns"]}
 
-    Do not include any text outside the JSON object.
-    """;
+      Do not include any text outside the JSON object.
+      """;
   private static final int DEFAULT_TIMEOUT_MS = 30000;
 
   private static final List<String> DEFAULT_REJECTED_CATEGORIES = List.of(
@@ -164,25 +171,49 @@ public class LlmImagePolicy implements HttpPolicy {
       )
       .toList()
       .flatMapCompletable(results -> {
-        boolean modified = false;
+        List<ValidationResult> failures = results
+          .stream()
+          .filter(r -> !r.valid())
+          .toList();
+
         for (ValidationResult result : results) {
           log.info(
             "Validation result for image at {}: {}",
             String.join(".", result.image().jsonPath()),
             result.valid() ? "PASSED" : "FAILED"
           );
-          if (!result.valid()) {
-            redactImage(requestBody, result.image().jsonPath());
-            modified = true;
-          }
         }
-        if (modified) {
+
+        if (failures.isEmpty()) {
+          return Completable.complete();
+        }
+
+        // Check violation mode from config
+        ViolationMode mode = effectiveConfig.getOnViolation() != null
+          ? effectiveConfig.getOnViolation()
+          : ViolationMode.BLOCK;
+
+        if (mode == ViolationMode.BLOCK) {
           log.info(
-            "Request body modified: {} image(s) redacted",
-            results.stream().filter(r -> !r.valid()).count()
+            "Blocking request: {} image(s) failed validation",
+            failures.size()
           );
-          ctx.request().body(Buffer.buffer(requestBody.encode()));
+          return ctx.interruptWith(
+            new ExecutionFailure(BLOCK_STATUS_CODE)
+              .key(BLOCK_ERROR_KEY)
+              .message(BLOCK_ERROR_MESSAGE)
+          );
         }
+
+        // REDACT mode: replace flagged images with placeholder
+        for (ValidationResult failure : failures) {
+          redactImage(requestBody, failure.image().jsonPath());
+        }
+        log.info(
+          "Request body modified: {} image(s) redacted",
+          failures.size()
+        );
+        ctx.request().body(Buffer.buffer(requestBody.encode()));
         return Completable.complete();
       });
   }
@@ -207,11 +238,16 @@ public class LlmImagePolicy implements HttpPolicy {
       ? config.getAcceptedCategories()
       : DEFAULT_ACCEPTED_CATEGORIES;
 
-    // If validationPrompt is explicitly set, use it; otherwise build from categories
+    // If validationPrompt is explicitly set, use it; otherwise build from
+    // categories
     String validationPrompt = config.getValidationPrompt() != null &&
       !config.getValidationPrompt().isBlank()
       ? config.getValidationPrompt()
       : buildValidationPrompt(rejectedCategories, acceptedCategories);
+
+    ViolationMode onViolation = config.getOnViolation() != null
+      ? config.getOnViolation()
+      : ViolationMode.BLOCK;
 
     return LlmImagePolicyConfiguration
       .builder()
@@ -221,6 +257,7 @@ public class LlmImagePolicy implements HttpPolicy {
       .timeoutMs(timeoutMs)
       .rejectedCategories(rejectedCategories)
       .acceptedCategories(acceptedCategories)
+      .onViolation(onViolation)
       .build();
   }
 

--- a/src/main/java/io/gravitee/policy/llm/image/LlmImagePolicyConfiguration.java
+++ b/src/main/java/io/gravitee/policy/llm/image/LlmImagePolicyConfiguration.java
@@ -30,7 +30,9 @@ import lombok.Setter;
 @Builder
 public class LlmImagePolicyConfiguration implements PolicyConfiguration {
 
-  /** Vision model endpoint URL (e.g., http://localhost:8000/v1/chat/completions) */
+  /**
+   * Vision model endpoint URL (e.g., http://localhost:8000/v1/chat/completions)
+   */
   private String visionEndpoint;
 
   /** Model name to use for vision analysis */
@@ -64,4 +66,8 @@ public class LlmImagePolicyConfiguration implements PolicyConfiguration {
     "Artistic content without explicit material",
     "General photography, illustrations, diagrams"
   );
+
+  /** Action to take when image validation fails */
+  @Builder.Default
+  private ViolationMode onViolation = ViolationMode.BLOCK;
 }

--- a/src/main/java/io/gravitee/policy/llm/image/ViolationMode.java
+++ b/src/main/java/io/gravitee/policy/llm/image/ViolationMode.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.policy.llm.image;
+
+/**
+ * Defines the action to take when image validation fails.
+ */
+public enum ViolationMode {
+  /** Block the request and return an error response */
+  BLOCK,
+
+  /** Replace flagged images with placeholder text and continue processing */
+  REDACT,
+}

--- a/src/main/resources/schemas/schema-form.json
+++ b/src/main/resources/schemas/schema-form.json
@@ -61,6 +61,13 @@
         "General photography, illustrations, diagrams"
       ],
       "description": "List of content categories that should be accepted"
+    },
+    "onViolation": {
+      "title": "On Violation",
+      "type": "string",
+      "default": "BLOCK",
+      "enum": ["BLOCK", "REDACT"],
+      "description": "Action when image validation fails: BLOCK (reject request) or REDACT (replace with placeholder)"
     }
   },
   "required": ["visionEndpoint"]

--- a/src/test/java/io/gravitee/policy/llm/image/LlmImagePolicyTest.java
+++ b/src/test/java/io/gravitee/policy/llm/image/LlmImagePolicyTest.java
@@ -23,15 +23,28 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import io.gravitee.gateway.api.buffer.Buffer;
+import io.gravitee.gateway.api.buffer.Buffer;
+import io.gravitee.gateway.reactive.api.ExecutionFailure;
+import io.gravitee.gateway.reactive.api.context.http.HttpPlainExecutionContext;
 import io.gravitee.gateway.reactive.api.context.http.HttpPlainExecutionContext;
 import io.gravitee.gateway.reactive.api.context.http.HttpPlainRequest;
+import io.gravitee.gateway.reactive.api.context.http.HttpPlainRequest;
+import io.reactivex.rxjava3.core.Completable;
+import io.reactivex.rxjava3.core.Maybe;
 import io.reactivex.rxjava3.core.Maybe;
 import io.reactivex.rxjava3.core.Single;
+import io.reactivex.rxjava3.core.Single;
+import io.reactivex.rxjava3.observers.TestObserver;
 import io.reactivex.rxjava3.observers.TestObserver;
 import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
 import io.vertx.core.json.JsonObject;
 import io.vertx.rxjava3.core.Vertx;
+import io.vertx.rxjava3.core.Vertx;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import org.mockito.ArgumentCaptor;
 
 class LlmImagePolicyTest {
@@ -66,7 +79,7 @@ class LlmImagePolicyTest {
     VisionModelClient client = mock(VisionModelClient.class);
     when(client.validateImage(any())).thenReturn(Single.just(false));
 
-    LlmImagePolicy policy = new TestPolicy(config(), client);
+    LlmImagePolicy policy = new TestPolicy(redactConfig(), client);
 
     Vertx vertx = Vertx.vertx();
     try {
@@ -107,7 +120,7 @@ class LlmImagePolicyTest {
         return Single.just(!image.imageUrl().contains("bad"));
       });
 
-    LlmImagePolicy policy = new TestPolicy(config(), client);
+    LlmImagePolicy policy = new TestPolicy(redactConfig(), client);
 
     Vertx vertx = Vertx.vertx();
     try {
@@ -147,6 +160,82 @@ class LlmImagePolicyTest {
       .builder()
       .visionEndpoint("http://localhost:8000/v1/chat/completions")
       .build();
+  }
+
+  private static LlmImagePolicyConfiguration redactConfig() {
+    return LlmImagePolicyConfiguration
+      .builder()
+      .visionEndpoint("http://localhost:8000/v1/chat/completions")
+      .onViolation(ViolationMode.REDACT)
+      .build();
+  }
+
+  // ========================================
+  // BLOCK MODE TESTS
+  // ========================================
+
+  @Test
+  void blocksRequestWhenValidationFailsInBlockMode() {
+    VisionModelClient client = mock(VisionModelClient.class);
+    when(client.validateImage(any())).thenReturn(Single.just(false));
+
+    LlmImagePolicy policy = new TestPolicy(config(), client);
+
+    Vertx vertx = Vertx.vertx();
+    try {
+      HttpPlainExecutionContext ctx = mock(HttpPlainExecutionContext.class);
+      HttpPlainRequest request = mock(HttpPlainRequest.class);
+      when(ctx.request()).thenReturn(request);
+      when(ctx.getComponent(Vertx.class)).thenReturn(vertx);
+      when(request.body())
+        .thenReturn(Maybe.just(Buffer.buffer(singleImageRequest().encode())));
+      when(ctx.interruptWith(any(ExecutionFailure.class)))
+        .thenReturn(Completable.complete());
+
+      TestObserver<Void> observer = policy.onRequest(ctx).test();
+      observer.assertComplete();
+
+      ArgumentCaptor<ExecutionFailure> failureCaptor = ArgumentCaptor.forClass(
+        ExecutionFailure.class
+      );
+      verify(ctx).interruptWith(failureCaptor.capture());
+
+      ExecutionFailure failure = failureCaptor.getValue();
+      assertThat(failure.statusCode()).isEqualTo(400);
+      assertThat(failure.key()).isEqualTo("IMAGE_VALIDATION_FAILED");
+      assertThat(failure.message())
+        .isEqualTo("Request blocked: inappropriate image(s) detected");
+
+      verify(request, never()).body(any(Buffer.class));
+    } finally {
+      vertx.close();
+    }
+  }
+
+  @Test
+  void passesRequestWhenValidationSucceedsInBlockMode() {
+    VisionModelClient client = mock(VisionModelClient.class);
+    when(client.validateImage(any())).thenReturn(Single.just(true));
+
+    LlmImagePolicy policy = new TestPolicy(config(), client);
+
+    Vertx vertx = Vertx.vertx();
+    try {
+      HttpPlainExecutionContext ctx = mock(HttpPlainExecutionContext.class);
+      HttpPlainRequest request = mock(HttpPlainRequest.class);
+      when(ctx.request()).thenReturn(request);
+      when(ctx.getComponent(Vertx.class)).thenReturn(vertx);
+      when(request.body())
+        .thenReturn(Maybe.just(Buffer.buffer(singleImageRequest().encode())));
+
+      TestObserver<Void> observer = policy.onRequest(ctx).test();
+      observer.assertComplete();
+
+      verify(ctx, never()).interruptWith(any(ExecutionFailure.class));
+      verify(request, never()).body(any(Buffer.class));
+    } finally {
+      vertx.close();
+    }
   }
 
   private static JsonObject singleImageRequest() {

--- a/src/test/java/io/gravitee/policy/llm/image/LlmImagePolicyTest.java
+++ b/src/test/java/io/gravitee/policy/llm/image/LlmImagePolicyTest.java
@@ -23,28 +23,17 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import io.gravitee.gateway.api.buffer.Buffer;
-import io.gravitee.gateway.api.buffer.Buffer;
 import io.gravitee.gateway.reactive.api.ExecutionFailure;
 import io.gravitee.gateway.reactive.api.context.http.HttpPlainExecutionContext;
-import io.gravitee.gateway.reactive.api.context.http.HttpPlainExecutionContext;
-import io.gravitee.gateway.reactive.api.context.http.HttpPlainRequest;
 import io.gravitee.gateway.reactive.api.context.http.HttpPlainRequest;
 import io.reactivex.rxjava3.core.Completable;
 import io.reactivex.rxjava3.core.Maybe;
-import io.reactivex.rxjava3.core.Maybe;
-import io.reactivex.rxjava3.core.Single;
 import io.reactivex.rxjava3.core.Single;
 import io.reactivex.rxjava3.observers.TestObserver;
-import io.reactivex.rxjava3.observers.TestObserver;
-import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
-import io.vertx.core.json.JsonObject;
-import io.vertx.rxjava3.core.Vertx;
 import io.vertx.rxjava3.core.Vertx;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.Test;
-import org.mockito.ArgumentCaptor;
 import org.mockito.ArgumentCaptor;
 
 class LlmImagePolicyTest {
@@ -170,6 +159,14 @@ class LlmImagePolicyTest {
       .build();
   }
 
+  private static LlmImagePolicyConfiguration blockConfig() {
+    return LlmImagePolicyConfiguration
+      .builder()
+      .visionEndpoint("http://localhost:8000/v1/chat/completions")
+      .onViolation(ViolationMode.BLOCK)
+      .build();
+  }
+
   // ========================================
   // BLOCK MODE TESTS
   // ========================================
@@ -179,7 +176,7 @@ class LlmImagePolicyTest {
     VisionModelClient client = mock(VisionModelClient.class);
     when(client.validateImage(any())).thenReturn(Single.just(false));
 
-    LlmImagePolicy policy = new TestPolicy(config(), client);
+    LlmImagePolicy policy = new TestPolicy(blockConfig(), client);
 
     Vertx vertx = Vertx.vertx();
     try {
@@ -217,7 +214,7 @@ class LlmImagePolicyTest {
     VisionModelClient client = mock(VisionModelClient.class);
     when(client.validateImage(any())).thenReturn(Single.just(true));
 
-    LlmImagePolicy policy = new TestPolicy(config(), client);
+    LlmImagePolicy policy = new TestPolicy(blockConfig(), client);
 
     Vertx vertx = Vertx.vertx();
     try {


### PR DESCRIPTION
Closes #3

## Summary

Adds a configuration option `onViolation` to choose how the policy handles flagged images:

| Mode | Behavior |
|------|----------|
| **BLOCK** (default) | Return 400 error and block the request |
| **REDACT** | Replace flagged images with placeholder text |

> **Note:** BLOCK is intentionally the default per explicit user request during planning.

## Changes

### New File
- `ViolationMode.java` - Enum defining BLOCK and REDACT modes

### Modified Files
- `LlmImagePolicyConfiguration.java` - Added `onViolation` field with BLOCK as default
- `schema-form.json` - Added dropdown for selecting violation mode
- `LlmImagePolicy.java` - Updated validation logic to support blocking and redaction
- `LlmImagePolicyTest.java` - Added tests for block mode, updated existing tests with explicit configs

## Verification

Tests run: 22, Failures: 0, Errors: 0

New tests added:
- `blocksRequestWhenValidationFailsInBlockMode()`
- `passesRequestWhenValidationSucceedsInBlockMode()`